### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/Publish_Backend_Package.yml
+++ b/.github/workflows/Publish_Backend_Package.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         cp server/.env.example server/api/.env
     - name: Build and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: hackforla/311-data/backend
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/Publish_Frontend_Package.yml
+++ b/.github/workflows/Publish_Frontend_Package.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: hackforla/311-data/frontend
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore